### PR TITLE
Fix broken test and clean up dependencies

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile("com.fasterxml.jackson.core:jackson-databind")
     compile("org.springframework.hateoas:spring-hateoas")
     compile("org.springframework.plugin:spring-plugin-core:1.1.0.RELEASE")
-    compile("com.jayway.jsonpath:json-path:0.9.1")
+    testCompile("com.jayway.jsonpath:json-path")
     testCompile("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -25,10 +25,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter-web")
-    compile("com.fasterxml.jackson.core:jackson-databind")
-    compile("org.springframework.hateoas:spring-hateoas")
-    compile("org.springframework.plugin:spring-plugin-core:1.1.0.RELEASE")
+    compile("org.springframework.boot:spring-boot-starter-hateoas")
     testCompile("com.jayway.jsonpath:json-path")
     testCompile("org.springframework.boot:spring-boot-starter-test")
 }

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -16,20 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.plugin</groupId>
-            <artifactId>spring-plugin-core</artifactId>
-            <version>1.1.0.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.hateoas</groupId>
-            <artifactId>spring-hateoas</artifactId>
+            <artifactId>spring-boot-starter-hateoas</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -28,17 +28,17 @@
             <version>1.1.0.RELEASE</version>
         </dependency>
         <dependency>
-        	<groupId>com.jayway.jsonpath</groupId>
-        	<artifactId>json-path</artifactId>
-        	<version>0.9.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile("com.fasterxml.jackson.core:jackson-databind")
     compile("org.springframework.hateoas:spring-hateoas")
     compile("org.springframework.plugin:spring-plugin-core:1.1.0.RELEASE")
-    compile("com.jayway.jsonpath:json-path:0.9.1")
+    testCompile("com.jayway.jsonpath:json-path")
     testCompile("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -25,10 +25,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter-web")
-    compile("com.fasterxml.jackson.core:jackson-databind")
-    compile("org.springframework.hateoas:spring-hateoas")
-    compile("org.springframework.plugin:spring-plugin-core:1.1.0.RELEASE")
+    compile("org.springframework.boot:spring-boot-starter-hateoas")
     testCompile("com.jayway.jsonpath:json-path")
     testCompile("org.springframework.boot:spring-boot-starter-test")
 }

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -16,20 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.plugin</groupId>
-            <artifactId>spring-plugin-core</artifactId>
-            <version>1.1.0.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.hateoas</groupId>
-            <artifactId>spring-hateoas</artifactId>
+            <artifactId>spring-boot-starter-hateoas</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -28,17 +28,17 @@
             <version>1.1.0.RELEASE</version>
         </dependency>
         <dependency>
-        	<groupId>com.jayway.jsonpath</groupId>
-        	<artifactId>json-path</artifactId>
-        	<version>0.9.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The included [test was failing](https://travis-ci.org/spring-guides/gs-rest-hateoas/builds/91422014) due to using the incompatible version 0.9.1 of `json-path`:
```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.345 sec <<< FAILURE! - in hello.HelloTests
envEndpointNotHidden(hello.HelloTests)  Time elapsed: 0.217 sec  <<< ERROR!
java.lang.NoClassDefFoundError: com/jayway/jsonpath/Predicate
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at org.springframework.hateoas.client.Traverson$TraversalBuilder.toObject(Traverson.java:337)
        at hello.HelloTests.envEndpointNotHidden(HelloTests.java:32)
```

This pull request fixes that by using spring-boot's parent pom version management. It also cleans simplifies the dependencies:
- no more explicit versioning of spring-plugin-core (which was also out of date)
- json-path is test-scope only
- utilize spring-boot-starter-hateoas in place of 3 dependencies

I've signed the CLA
