### PR TITLE
Migrating to Spring HATEOAS 1.x

### DIFF
--- a/complete/src/main/java/hello/Greeting.java
+++ b/complete/src/main/java/hello/Greeting.java
@@ -1,11 +1,11 @@
 package hello;
 
-import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.RepresentationModel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Greeting extends ResourceSupport {
+public class Greeting extends RepresentationModel {
 
 	private final String content;
 

--- a/complete/src/main/java/hello/Greeting.java
+++ b/complete/src/main/java/hello/Greeting.java
@@ -5,7 +5,7 @@ import org.springframework.hateoas.RepresentationModel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Greeting extends RepresentationModel {
+public class Greeting extends RepresentationModel<Greeting> {
 
 	private final String content;
 

--- a/complete/src/main/java/hello/GreetingController.java
+++ b/complete/src/main/java/hello/GreetingController.java
@@ -1,6 +1,6 @@
 package hello;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION
The project was upgraded to Spring Boot 2.2.1.RELEASE which includes Spring HATEOAS 1.0.1.RELEASE which brings some breaking changes causing the project not to compile.

The aim of my PR is to migrate to the new API and fix these compilation errors.